### PR TITLE
Add test project scaffolds

### DIFF
--- a/ACS.Service.Tests.Integration/ACS.Service.Tests.Integration.csproj
+++ b/ACS.Service.Tests.Integration/ACS.Service.Tests.Integration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ACS.Service\ACS.Service.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ACS.Service.Tests.Integration/GlobalUsings.cs
+++ b/ACS.Service.Tests.Integration/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ACS.Service.Tests.Integration/UnitTest1.cs
+++ b/ACS.Service.Tests.Integration/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace ACS.Service.Tests.Integration;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void Placeholder()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/ACS.Service.Tests.Unit/ACS.Service.Tests.Unit.csproj
+++ b/ACS.Service.Tests.Unit/ACS.Service.Tests.Unit.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ACS.Service\ACS.Service.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ACS.Service.Tests.Unit/GlobalUsings.cs
+++ b/ACS.Service.Tests.Unit/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ACS.Service.Tests.Unit/UnitTest1.cs
+++ b/ACS.Service.Tests.Unit/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace ACS.Service.Tests.Unit;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void Placeholder()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/ACS.WebApi.Tests.Integration/ACS.WebApi.Tests.Integration.csproj
+++ b/ACS.WebApi.Tests.Integration/ACS.WebApi.Tests.Integration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ACS.WebApi\ACS.WebApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ACS.WebApi.Tests.Integration/GlobalUsings.cs
+++ b/ACS.WebApi.Tests.Integration/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ACS.WebApi.Tests.Integration/UnitTest1.cs
+++ b/ACS.WebApi.Tests.Integration/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace ACS.WebApi.Tests.Integration;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void Placeholder()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/ACS.WebApi.Tests.Unit/ACS.WebApi.Tests.Unit.csproj
+++ b/ACS.WebApi.Tests.Unit/ACS.WebApi.Tests.Unit.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ACS.WebApi\ACS.WebApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ACS.WebApi.Tests.Unit/GlobalUsings.cs
+++ b/ACS.WebApi.Tests.Unit/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ACS.WebApi.Tests.Unit/UnitTest1.cs
+++ b/ACS.WebApi.Tests.Unit/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace ACS.WebApi.Tests.Unit;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void Placeholder()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/ACS.WebResources.Tests.Integration/ACS.WebResources.Tests.Integration.csproj
+++ b/ACS.WebResources.Tests.Integration/ACS.WebResources.Tests.Integration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ACS.WebResources\ACS.WebResources.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ACS.WebResources.Tests.Integration/GlobalUsings.cs
+++ b/ACS.WebResources.Tests.Integration/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ACS.WebResources.Tests.Integration/UnitTest1.cs
+++ b/ACS.WebResources.Tests.Integration/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace ACS.WebResources.Tests.Integration;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void Placeholder()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/ACS.WebResources.Tests.Unit/ACS.WebResources.Tests.Unit.csproj
+++ b/ACS.WebResources.Tests.Unit/ACS.WebResources.Tests.Unit.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ACS.WebResources\ACS.WebResources.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ACS.WebResources.Tests.Unit/GlobalUsings.cs
+++ b/ACS.WebResources.Tests.Unit/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ACS.WebResources.Tests.Unit/UnitTest1.cs
+++ b/ACS.WebResources.Tests.Unit/UnitTest1.cs
@@ -1,0 +1,11 @@
+namespace ACS.WebResources.Tests.Unit;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void Placeholder()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/ACS.sln
+++ b/ACS.sln
@@ -13,6 +13,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ACS.Service.Tests", "ACS.Se
 EndProject
 Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "ACS.Database", "ACS.Database\ACS.Database.sqlproj", "{5BDDA714-4942-4ABF-ACBD-ACB24F5FB99C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ACS.Service.Tests.Unit", "ACS.Service.Tests.Unit\ACS.Service.Tests.Unit.csproj", "{3E67D1E9-6948-487B-AFD5-250E39040AAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ACS.Service.Tests.Integration", "ACS.Service.Tests.Integration\ACS.Service.Tests.Integration.csproj", "{F5A4A922-2739-49B3-AD14-AF0FE4A1A044}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ACS.WebApi.Tests.Unit", "ACS.WebApi.Tests.Unit\ACS.WebApi.Tests.Unit.csproj", "{91F472CF-3565-43CA-B82E-BE0B5F926070}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ACS.WebApi.Tests.Integration", "ACS.WebApi.Tests.Integration\ACS.WebApi.Tests.Integration.csproj", "{819967C0-46FE-44D5-B9DA-E1F1637646E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ACS.WebResources.Tests.Unit", "ACS.WebResources.Tests.Unit\ACS.WebResources.Tests.Unit.csproj", "{98D729BC-6B1A-4DCB-AD6B-B714AA7E496F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ACS.WebResources.Tests.Integration", "ACS.WebResources.Tests.Integration\ACS.WebResources.Tests.Integration.csproj", "{C36DF226-977B-4F60-87D3-AA78DA568FE7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +53,30 @@ Global
 		{5BDDA714-4942-4ABF-ACBD-ACB24F5FB99C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5BDDA714-4942-4ABF-ACBD-ACB24F5FB99C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5BDDA714-4942-4ABF-ACBD-ACB24F5FB99C}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{3E67D1E9-6948-487B-AFD5-250E39040AAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E67D1E9-6948-487B-AFD5-250E39040AAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E67D1E9-6948-487B-AFD5-250E39040AAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E67D1E9-6948-487B-AFD5-250E39040AAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5A4A922-2739-49B3-AD14-AF0FE4A1A044}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5A4A922-2739-49B3-AD14-AF0FE4A1A044}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5A4A922-2739-49B3-AD14-AF0FE4A1A044}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5A4A922-2739-49B3-AD14-AF0FE4A1A044}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91F472CF-3565-43CA-B82E-BE0B5F926070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91F472CF-3565-43CA-B82E-BE0B5F926070}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91F472CF-3565-43CA-B82E-BE0B5F926070}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91F472CF-3565-43CA-B82E-BE0B5F926070}.Release|Any CPU.Build.0 = Release|Any CPU
+		{819967C0-46FE-44D5-B9DA-E1F1637646E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{819967C0-46FE-44D5-B9DA-E1F1637646E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{819967C0-46FE-44D5-B9DA-E1F1637646E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{819967C0-46FE-44D5-B9DA-E1F1637646E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98D729BC-6B1A-4DCB-AD6B-B714AA7E496F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98D729BC-6B1A-4DCB-AD6B-B714AA7E496F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98D729BC-6B1A-4DCB-AD6B-B714AA7E496F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98D729BC-6B1A-4DCB-AD6B-B714AA7E496F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C36DF226-977B-4F60-87D3-AA78DA568FE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C36DF226-977B-4F60-87D3-AA78DA568FE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C36DF226-977B-4F60-87D3-AA78DA568FE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C36DF226-977B-4F60-87D3-AA78DA568FE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/projects/test_improvement.md
+++ b/docs/projects/test_improvement.md
@@ -1,14 +1,15 @@
 # Test Improvement Initiative
 
-**Status:** Planned
+**Status:** In Progress
 
 ## Pending Tasks
 - Review existing tests
 - Increase coverage
 
 ## Current Tasks
-- None
+- Expand test coverage
 
 ## Completed Tasks
+- Created unit and integration test project scaffolds for each assembly
 - Initial placeholder created
 


### PR DESCRIPTION
## Summary
- add placeholder unit and integration test projects for WebApi, Service and WebResources
- update solution to include the new test projects
- document progress in the **Test Improvement Initiative** project

## Testing
- `dotnet test ACS.Service.Tests.Unit/ACS.Service.Tests.Unit.csproj`
- `dotnet test ACS.Service.Tests.Integration/ACS.Service.Tests.Integration.csproj`
- `dotnet test ACS.WebApi.Tests.Unit/ACS.WebApi.Tests.Unit.csproj`
- `dotnet test ACS.WebApi.Tests.Integration/ACS.WebApi.Tests.Integration.csproj`
- `dotnet test ACS.WebResources.Tests.Unit/ACS.WebResources.Tests.Unit.csproj`
- `dotnet test ACS.WebResources.Tests.Integration/ACS.WebResources.Tests.Integration.csproj`
- `dotnet test ACS.Service.Tests/ACS.Service.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_b_68454c5e409483299e1aa9a35b7030cb