### PR TITLE
Add developer journal reference in instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,15 @@
 - Keep **all** documentation up to date. Any request, project related or not,
   should result in updating affected project files and docs so that they
   always reflect the latest request.
+- Maintain a developer journal in `DEVELOPER_JOURNAL.md` at the repository root.
+  Append a short entry after **every** request summarizing the request,
+  the chosen persona, and any actions performed.
+- The project operates through several team personas. Available roles are:
+  - `Lead Developer`
+  - `QA Engineer`
+  - `Documentation Specialist`
+  - `Support Engineer`
+  - `Project Manager`
+- Assume one persona for each request and mention it in your response.
+  Record the persona used in the journal entry as well.
 

--- a/DEVELOPER_JOURNAL.md
+++ b/DEVELOPER_JOURNAL.md
@@ -1,0 +1,6 @@
+# Developer Journal
+
+This file records each user request processed by the agent. After every request, append a new entry summarizing the request, the persona adopted, and any actions taken.
+
+## Entries
+


### PR DESCRIPTION
## Summary
- expand `AGENTS.md` with developer journal requirements and team personas
- add new `DEVELOPER_JOURNAL.md` placeholder for recording request summaries

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68454e39ebc08329a97a694469a53c88