### PR TITLE
Add failing integration tests

### DIFF
--- a/ACS.Service.Tests.Integration/AddUserToGroupNormalizerTests.cs
+++ b/ACS.Service.Tests.Integration/AddUserToGroupNormalizerTests.cs
@@ -1,0 +1,27 @@
+using ACS.Service.Data.Models;
+using System.Reflection;
+
+namespace ACS.Service.Tests.Integration;
+
+[TestClass]
+public class AddUserToGroupNormalizerTests
+{
+    [TestMethod]
+    public void Execute_ShouldAddUserToGroupAndSetBackReference()
+    {
+        var user = new User { Id = 1 };
+        var group = new Group { Id = 10, Users = new List<User>() };
+
+        var normalizerType = Type.GetType("ACS.Service.Delegates.Normalizers.AddUserToGroupNormalizer, ACS.Service");
+        Assert.IsNotNull(normalizerType, "Normalizer type should exist");
+
+        normalizerType!.GetProperty("Users")!.SetValue(null, new List<User> { user });
+        normalizerType.GetProperty("Groups")!.SetValue(null, new List<Group> { group });
+
+        var method = normalizerType.GetMethod("Execute", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        method!.Invoke(null, new object[] { user.Id, group.Id });
+
+        Assert.IsTrue(group.Users.Contains(user), "Group should contain user after execution");
+        Assert.AreEqual(group, user.Group, "User should reference the group");
+    }
+}

--- a/ACS.WebApi.Tests.Integration/ACS.WebApi.Tests.Integration.csproj
+++ b/ACS.WebApi.Tests.Integration/ACS.WebApi.Tests.Integration.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ACS.WebApi.Tests.Integration/WeatherApiTests.cs
+++ b/ACS.WebApi.Tests.Integration/WeatherApiTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace ACS.WebApi.Tests.Integration;
+
+[TestClass]
+public class WeatherApiTests
+{
+    [TestMethod]
+    public async Task WeatherForecast_ReturnsSuccess()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/WeatherForecast");
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task GetGroups_ReturnsOk()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/groups");
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/ACS.WebApi/Program.Public.cs
+++ b/ACS.WebApi/Program.Public.cs
@@ -1,0 +1,3 @@
+namespace ACS.WebApi;
+
+public partial class Program { }

--- a/ACS.WebResources.Tests.Integration/ResourcesTests.cs
+++ b/ACS.WebResources.Tests.Integration/ResourcesTests.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+
+namespace ACS.WebResources.Tests.Integration;
+
+[TestClass]
+public class ResourcesTests
+{
+    [TestMethod]
+    public void ExpectedResource_IsPresent()
+    {
+        var assembly = typeof(ACS.WebResources.Class1).Assembly;
+        var resourceNames = assembly.GetManifestResourceNames();
+
+        Assert.IsTrue(resourceNames.Any(n => n.EndsWith("Strings.resx")),
+            "Embedded resource Strings.resx should exist");
+    }
+}

--- a/DEVELOPER_JOURNAL.md
+++ b/DEVELOPER_JOURNAL.md
@@ -9,3 +9,8 @@ This file records each user request processed by the agent. After every request,
 
 Created `scripts/setup_dotnet.sh` to install the .NET SDK for the Codex environment. Updated `README.md` and `docs/developer_guide.md` with instructions about using the script.
 
+
+### 2025-06-08
+**Persona:** QA Engineer
+
+Added initial integration tests across projects. New tests intentionally cover missing functionality and currently fail. Updated test improvement project documentation.

--- a/docs/projects/test_improvement.md
+++ b/docs/projects/test_improvement.md
@@ -12,4 +12,5 @@
 ## Completed Tasks
 - Created unit and integration test project scaffolds for each assembly
 - Initial placeholder created
+- Added initial integration tests for service, web API, and web resources
 


### PR DESCRIPTION
## Summary
- add baseline public Program type to allow WebApplicationFactory
- implement integration tests for Web API, service normalizers, and web resources
- reference `Microsoft.AspNetCore.Mvc.Testing`
- document progress in Test Improvement Initiative
- log work in developer journal

## Testing
- `dotnet test` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_b_6845659961f48329882156d30cf0b3da