### PR TITLE
Resolve merge conflicts and clarify docs

### DIFF
--- a/DEVELOPER_JOURNAL.md
+++ b/DEVELOPER_JOURNAL.md
@@ -8,4 +8,32 @@ This file records each user request processed by the agent. After every request,
 **Persona:** Support Engineer
 
 Created `scripts/setup_dotnet.sh` to install the .NET SDK for the Codex environment. Updated `README.md` and `docs/developer_guide.md` with instructions about using the script.
+### 2025-06-08
+**Persona:** Documentation Specialist
 
+Reviewed the domain models and API controller structure at the user's request. Added an overview of the domain layer to `docs/service_overview.md` and noted the update in the project file.
+
+### 2025-06-08
+**Persona:** Support Engineer
+
+Answered a question about database setup. Confirmed the presence of a SQL Server database project (`ACS.Database`) with table creation scripts and `DataSeed.sql`. Updated `docs/database_design.md` and project documentation accordingly.
+
+### 2025-06-08
+**Persona:** Lead Developer
+
+Resolved merge conflicts with main branch and ensured documentation changes persisted.
+
+### 2025-06-08
+**Persona:** Lead Developer
+
+Addressed review feedback by clarifying domain entity locations in `docs/service_overview.md`, noting the merge resolution in the project file, and ensuring documentation stayed consistent.
+
+### 2025-06-08
+**Persona:** Lead Developer
+
+Merged `main` into the working branch and resolved conflicts in `DEVELOPER_JOURNAL.md`, `docs/projects/documenting_solution.md`, and `docs/service_overview.md`.
+
+### 2025-06-08
+**Persona:** Lead Developer
+
+Merged `main` again to address PR conflicts and removed leftover markers from documentation.

--- a/docs/database_design.md
+++ b/docs/database_design.md
@@ -1,6 +1,7 @@
 # Database Design
 
 The SQL project defines the tables required by the service. Each table is stored under the `Tables` folder and can be deployed using Visual Studio or `sqlpackage`.
+The project file `ACS.Database.sqlproj` defines the schema. Create scripts for each table live under the `ACS.Database/Tables` folder, and an optional data seed script is available at `ACS.Database/DataSeed.sql`.
 
 ## Schema
 Entities include `User`, `Role`, `PermissionScheme`, and supporting tables.

--- a/docs/projects/documenting_solution.md
+++ b/docs/projects/documenting_solution.md
@@ -12,3 +12,6 @@
 - Created project entry and outline
 - Set up initial documentation folder structure
 - Expanded initial documentation placeholders
+- Documented domain layer overview in `service_overview.md`
+- Documented database project file and seed script locations
+- Resolved merge conflict and verified domain layer documentation

--- a/docs/service_overview.md
+++ b/docs/service_overview.md
@@ -10,3 +10,8 @@ The Web API publishes controllers in the `ACS.WebApi` project. Requests are rout
 
 ## Workflows
 A typical request passes through the API, invokes a handler, performs database operations, and returns a response in JSON format.
+
+## Domain layer
+Domain entities live under `ACS.Service/Entities` and include types such as `User`, `Role`, and `Group`. These types inherit from an abstract `Entity` base class that tracks parent and child relationships and a set of `Permission` objects. The entities expose methods to add or remove children and manage permissions. Many of these methods delegate to *normalizer* helpers under `ACS.Service/Delegates/Normalizers`, which currently use in-memory lists and are marked internal for future database integration.
+
+The only API controller (`WeatherForecastController`) does not yet interact with these classes. Future controllers would call into the domain layer through normalizers or service helpers to persist entities and check permissions.


### PR DESCRIPTION
## Summary
- merge `main` again and remove conflict markers
- clarify domain entities live in `ACS.Service/Entities`
- keep completed tasks around database setup in project doc
- record merge resolution in the developer journal

## Testing
- `scripts/setup_dotnet.sh`
- `dotnet test ACS.sln`


------
https://chatgpt.com/codex/tasks/task_b_68456516a5a48329ac82cbcb9146b3eb