### PR TITLE
Enforce normalizer preconditions with exceptions

### DIFF
--- a/ACS.Service.Tests.Unit/NormalizersTests.cs
+++ b/ACS.Service.Tests.Unit/NormalizersTests.cs
@@ -179,6 +179,14 @@ public class NormalizersTests
     }
 
     [TestMethod]
+    public void AddGroupToGroupNormalizer_ThrowsWhenParentMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 2, ChildGroups = new List<GroupDM>() } };
+        AddGroupToGroupNormalizer.Groups = groups;
+        Assert.ThrowsException<InvalidOperationException>(() => AddGroupToGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
     public void AddRoleToGroupNormalizer_ThrowsWhenGroupMissing()
     {
         var roles = new List<RoleDM> { new RoleDM { Id = 3 } };
@@ -188,11 +196,29 @@ public class NormalizersTests
     }
 
     [TestMethod]
+    public void AddRoleToGroupNormalizer_ThrowsWhenRoleMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, Roles = new List<RoleDM>() } };
+        AddRoleToGroupNormalizer.Groups = groups;
+        AddRoleToGroupNormalizer.Roles = new List<RoleDM>();
+        Assert.ThrowsException<InvalidOperationException>(() => AddRoleToGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
     public void AddUserToGroupNormalizer_ThrowsWhenUserMissing()
     {
         var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
         AddUserToGroupNormalizer.Groups = groups;
         AddUserToGroupNormalizer.Users = new List<UserDM>();
+        Assert.ThrowsException<InvalidOperationException>(() => AddUserToGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void AddUserToGroupNormalizer_ThrowsWhenGroupMissing()
+    {
+        var users = new List<UserDM> { new UserDM { Id = 2 } };
+        AddUserToGroupNormalizer.Groups = new List<GroupDM>();
+        AddUserToGroupNormalizer.Users = users;
         Assert.ThrowsException<InvalidOperationException>(() => AddUserToGroupNormalizer.Execute(2, 1));
     }
 
@@ -210,6 +236,22 @@ public class NormalizersTests
     }
 
     [TestMethod]
+    public void RemoveGroupFromGroupNormalizer_ThrowsWhenParentMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 2, ChildGroups = new List<GroupDM>() } };
+        RemoveGroupFromGroupNormalizer.Groups = groups;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveGroupFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveGroupFromGroupNormalizer_ThrowsWhenChildMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, ChildGroups = new List<GroupDM>() } };
+        RemoveGroupFromGroupNormalizer.Groups = groups;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveGroupFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
     public void RemoveRoleFromGroupNormalizer_ThrowsWhenNotMember()
     {
         var groups = new List<GroupDM> { new GroupDM { Id = 1, Roles = new List<RoleDM>() } };
@@ -222,6 +264,24 @@ public class NormalizersTests
     }
 
     [TestMethod]
+    public void RemoveRoleFromGroupNormalizer_ThrowsWhenGroupMissing()
+    {
+        var roles = new List<RoleDM> { new RoleDM { Id = 3 } };
+        RemoveRoleFromGroupNormalizer.Groups = new List<GroupDM>();
+        RemoveRoleFromGroupNormalizer.Roles = roles;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveRoleFromGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
+    public void RemoveRoleFromGroupNormalizer_ThrowsWhenRoleMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, Roles = new List<RoleDM>() } };
+        RemoveRoleFromGroupNormalizer.Groups = groups;
+        RemoveRoleFromGroupNormalizer.Roles = new List<RoleDM>();
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveRoleFromGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
     public void RemoveUserFromGroupNormalizer_ThrowsWhenNotMember()
     {
         var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
@@ -230,6 +290,24 @@ public class NormalizersTests
         RemoveUserFromGroupNormalizer.Groups = groups;
         RemoveUserFromGroupNormalizer.Users = users;
 
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveUserFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveUserFromGroupNormalizer_ThrowsWhenGroupMissing()
+    {
+        var users = new List<UserDM> { new UserDM { Id = 2 } };
+        RemoveUserFromGroupNormalizer.Groups = new List<GroupDM>();
+        RemoveUserFromGroupNormalizer.Users = users;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveUserFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveUserFromGroupNormalizer_ThrowsWhenUserMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
+        RemoveUserFromGroupNormalizer.Groups = groups;
+        RemoveUserFromGroupNormalizer.Users = new List<UserDM>();
         Assert.ThrowsException<InvalidOperationException>(() => RemoveUserFromGroupNormalizer.Execute(2, 1));
     }
 

--- a/ACS.Service.Tests.Unit/NormalizersTests.cs
+++ b/ACS.Service.Tests.Unit/NormalizersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ACS.Service.Data.Models;
 using ACS.Service.Delegates.Normalizers;
 using ACS.Service.Domain;
@@ -167,5 +168,114 @@ public class NormalizersTests
         Assert.IsFalse(groups[0].ChildGroups.Contains(groups[1]));
         Assert.IsNull(groups[1].ParentGroup);
         Assert.AreEqual(0, groups[1].ParentGroupId);
+    }
+
+    [TestMethod]
+    public void AddGroupToGroupNormalizer_ThrowsWhenChildMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, ChildGroups = new List<GroupDM>() } };
+        AddGroupToGroupNormalizer.Groups = groups;
+        Assert.ThrowsException<InvalidOperationException>(() => AddGroupToGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void AddRoleToGroupNormalizer_ThrowsWhenGroupMissing()
+    {
+        var roles = new List<RoleDM> { new RoleDM { Id = 3 } };
+        AddRoleToGroupNormalizer.Groups = new List<GroupDM>();
+        AddRoleToGroupNormalizer.Roles = roles;
+        Assert.ThrowsException<InvalidOperationException>(() => AddRoleToGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
+    public void AddUserToGroupNormalizer_ThrowsWhenUserMissing()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
+        AddUserToGroupNormalizer.Groups = groups;
+        AddUserToGroupNormalizer.Users = new List<UserDM>();
+        Assert.ThrowsException<InvalidOperationException>(() => AddUserToGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveGroupFromGroupNormalizer_ThrowsWhenNotMember()
+    {
+        var groups = new List<GroupDM>
+        {
+            new GroupDM { Id = 1, ChildGroups = new List<GroupDM>() },
+            new GroupDM { Id = 2, ChildGroups = new List<GroupDM>() }
+        };
+
+        RemoveGroupFromGroupNormalizer.Groups = groups;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveGroupFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveRoleFromGroupNormalizer_ThrowsWhenNotMember()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, Roles = new List<RoleDM>() } };
+        var roles = new List<RoleDM> { new RoleDM { Id = 3 } };
+
+        RemoveRoleFromGroupNormalizer.Groups = groups;
+        RemoveRoleFromGroupNormalizer.Roles = roles;
+
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveRoleFromGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
+    public void RemoveUserFromGroupNormalizer_ThrowsWhenNotMember()
+    {
+        var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
+        var users = new List<UserDM> { new UserDM { Id = 2 } };
+
+        RemoveUserFromGroupNormalizer.Groups = groups;
+        RemoveUserFromGroupNormalizer.Users = users;
+
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveUserFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void AddGroupToGroupNormalizer_ThrowsWhenGroupsNull()
+    {
+        AddGroupToGroupNormalizer.Groups = null!;
+        Assert.ThrowsException<InvalidOperationException>(() => AddGroupToGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void AddRoleToGroupNormalizer_ThrowsWhenRolesNull()
+    {
+        AddRoleToGroupNormalizer.Groups = new List<GroupDM>();
+        AddRoleToGroupNormalizer.Roles = null!;
+        Assert.ThrowsException<InvalidOperationException>(() => AddRoleToGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
+    public void AddUserToGroupNormalizer_ThrowsWhenUsersNull()
+    {
+        AddUserToGroupNormalizer.Groups = new List<GroupDM>();
+        AddUserToGroupNormalizer.Users = null!;
+        Assert.ThrowsException<InvalidOperationException>(() => AddUserToGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveGroupFromGroupNormalizer_ThrowsWhenGroupsNull()
+    {
+        RemoveGroupFromGroupNormalizer.Groups = null!;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveGroupFromGroupNormalizer.Execute(2, 1));
+    }
+
+    [TestMethod]
+    public void RemoveRoleFromGroupNormalizer_ThrowsWhenRolesNull()
+    {
+        RemoveRoleFromGroupNormalizer.Groups = new List<GroupDM>();
+        RemoveRoleFromGroupNormalizer.Roles = null!;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveRoleFromGroupNormalizer.Execute(3, 1));
+    }
+
+    [TestMethod]
+    public void RemoveUserFromGroupNormalizer_ThrowsWhenUsersNull()
+    {
+        RemoveUserFromGroupNormalizer.Groups = new List<GroupDM>();
+        RemoveUserFromGroupNormalizer.Users = null!;
+        Assert.ThrowsException<InvalidOperationException>(() => RemoveUserFromGroupNormalizer.Execute(2, 1));
     }
 }

--- a/ACS.Service.Tests/GroupDomainTests.cs
+++ b/ACS.Service.Tests/GroupDomainTests.cs
@@ -7,7 +7,7 @@ using RoleDM = ACS.Service.Data.Models.Role;
 namespace ACS.Service.Tests
 {
     [TestClass]
-    public class GroupTests
+    public class GroupDomainTests
     {
         [TestMethod]
         public void AddGroup_ShouldAddGroupSuccessfully()

--- a/ACS.Service.Tests/UnitTest1.cs
+++ b/ACS.Service.Tests/UnitTest1.cs
@@ -1,4 +1,8 @@
 using ACS.Service.Domain;
+using ACS.Service.Delegates.Normalizers;
+using GroupDM = ACS.Service.Data.Models.Group;
+using UserDM = ACS.Service.Data.Models.User;
+using RoleDM = ACS.Service.Data.Models.Role;
 
 namespace ACS.Service.Tests
 {
@@ -11,6 +15,11 @@ namespace ACS.Service.Tests
             // Arrange
             var parentGroup = new Group { Id = 1, Name = "ParentGroup" };
             var childGroup = new Group { Id = 2, Name = "ChildGroup" };
+            AddGroupToGroupNormalizer.Groups = new List<GroupDM>
+            {
+                new GroupDM { Id = 1, ChildGroups = new List<GroupDM>() },
+                new GroupDM { Id = 2, ChildGroups = new List<GroupDM>() }
+            };
 
             // Act
             parentGroup.AddGroup(childGroup);
@@ -40,6 +49,12 @@ namespace ACS.Service.Tests
             var parentGroup = new Group { Id = 1, Name = "ParentGroup" };
             var childGroup = new Group { Id = 2, Name = "ChildGroup" };
             var grandChildGroup = new Group { Id = 3, Name = "GrandChildGroup" };
+            AddGroupToGroupNormalizer.Groups = new List<GroupDM>
+            {
+                new GroupDM { Id = 1, ChildGroups = new List<GroupDM>() },
+                new GroupDM { Id = 2, ChildGroups = new List<GroupDM>() },
+                new GroupDM { Id = 3, ChildGroups = new List<GroupDM>() }
+            };
 
             // Act
             parentGroup.AddGroup(childGroup);
@@ -55,6 +70,13 @@ namespace ACS.Service.Tests
             // Arrange
             var parentGroup = new Group { Id = 1, Name = "ParentGroup" };
             var childGroup = new Group { Id = 2, Name = "ChildGroup" };
+            var groups = new List<GroupDM>
+            {
+                new GroupDM { Id = 1, ChildGroups = new List<GroupDM>() },
+                new GroupDM { Id = 2, ChildGroups = new List<GroupDM>() }
+            };
+            AddGroupToGroupNormalizer.Groups = groups;
+            RemoveGroupFromGroupNormalizer.Groups = groups;
 
             parentGroup.AddGroup(childGroup);
 
@@ -71,6 +93,10 @@ namespace ACS.Service.Tests
             // Arrange
             var group = new Group { Id = 1, Name = "Group" };
             var user = new Domain.User { Id = 1, Name = "User" };
+            var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
+            var users = new List<UserDM> { new UserDM { Id = 1 } };
+            AddUserToGroupNormalizer.Groups = groups;
+            AddUserToGroupNormalizer.Users = users;
 
             // Act
             group.AddUser(user);
@@ -86,6 +112,12 @@ namespace ACS.Service.Tests
             // Arrange
             var group = new Group { Id = 1, Name = "Group" };
             var user = new Domain.User { Id = 1, Name = "User" };
+            var groups = new List<GroupDM> { new GroupDM { Id = 1, Users = new List<UserDM>() } };
+            var users = new List<UserDM> { new UserDM { Id = 1 } };
+            AddUserToGroupNormalizer.Groups = groups;
+            AddUserToGroupNormalizer.Users = users;
+            RemoveUserFromGroupNormalizer.Groups = groups;
+            RemoveUserFromGroupNormalizer.Users = users;
 
             group.AddUser(user);
 
@@ -103,6 +135,10 @@ namespace ACS.Service.Tests
             // Arrange
             var group = new Group { Id = 1, Name = "Group" };
             var role = new Role { Id = 1, Name = "Role" };
+            var groups = new List<GroupDM> { new GroupDM { Id = 1, Roles = new List<RoleDM>() } };
+            var roles = new List<RoleDM> { new RoleDM { Id = 1 } };
+            AddRoleToGroupNormalizer.Groups = groups;
+            AddRoleToGroupNormalizer.Roles = roles;
 
             // Act
             group.AddRole(role);
@@ -118,6 +154,12 @@ namespace ACS.Service.Tests
             // Arrange
             var group = new Group { Id = 1, Name = "Group" };
             var role = new Role { Id = 1, Name = "Role" };
+            var groups = new List<GroupDM> { new GroupDM { Id = 1, Roles = new List<RoleDM>() } };
+            var roles = new List<RoleDM> { new RoleDM { Id = 1 } };
+            AddRoleToGroupNormalizer.Groups = groups;
+            AddRoleToGroupNormalizer.Roles = roles;
+            RemoveRoleFromGroupNormalizer.Groups = groups;
+            RemoveRoleFromGroupNormalizer.Roles = roles;
 
             group.AddRole(role);
 

--- a/ACS.Service/Delegates/Normalizers/AddGroupToGroupNormalizer.cs
+++ b/ACS.Service/Delegates/Normalizers/AddGroupToGroupNormalizer.cs
@@ -1,14 +1,25 @@
+using System;
+using System.Linq;
 using ACS.Service.Data.Models;
 
 namespace ACS.Service.Delegates.Normalizers
 {
     internal static class AddGroupToGroupNormalizer
     {
-        public static List<Group> Groups { get; set; }
+        public static List<Group> Groups { get; set; } = null!;
         public static void Execute(int childGroupId, int parentGroupId)
         {
-            var parent = Groups.Single(x => x.Id == parentGroupId);
-            var child = Groups.Single(x => x.Id == childGroupId);
+            if (Groups is null)
+            {
+                throw new InvalidOperationException("Groups collection has not been initialized.");
+            }
+
+            var parent = Groups.SingleOrDefault(x => x.Id == parentGroupId)
+                ?? throw new InvalidOperationException($"Parent group {parentGroupId} not found.");
+
+            var child = Groups.SingleOrDefault(x => x.Id == childGroupId)
+                ?? throw new InvalidOperationException($"Child group {childGroupId} not found.");
+
             parent.ChildGroups.Add(child);
             child.ParentGroup = parent;
             child.ParentGroupId = parent.Id;

--- a/ACS.Service/Delegates/Normalizers/AddRoleToGroupNormalizer.cs
+++ b/ACS.Service/Delegates/Normalizers/AddRoleToGroupNormalizer.cs
@@ -1,15 +1,31 @@
-﻿using ACS.Service.Data.Models;
+using System;
+using System.Linq;
+using ACS.Service.Data.Models;
 
 namespace ACS.Service.Delegates.Normalizers
 {
     internal class AddRoleToGroupNormalizer
     {
-        public static List<Group> Groups { get; set; }
-        public static List<Role> Roles { get; set; }
+        public static List<Group> Groups { get; set; } = null!;
+        public static List<Role> Roles { get; set; } = null!;
         public static void Execute(int roleId, int groupId)
         {
-            var role = Roles.Single(x => x.Id == roleId);
-            var group = Groups.Single(x => x.Id == groupId);
+            if (Groups is null)
+            {
+                throw new InvalidOperationException("Groups collection has not been initialized.");
+            }
+
+            if (Roles is null)
+            {
+                throw new InvalidOperationException("Roles collection has not been initialized.");
+            }
+
+            var role = Roles.SingleOrDefault(x => x.Id == roleId)
+                ?? throw new InvalidOperationException($"Role {roleId} not found.");
+
+            var group = Groups.SingleOrDefault(x => x.Id == groupId)
+                ?? throw new InvalidOperationException($"Group {groupId} not found.");
+
             group.Roles.Add(role);
             role.Group = group;
             role.GroupId = group.Id;

--- a/ACS.Service/Delegates/Normalizers/AddUserToGroupNormalizer.cs
+++ b/ACS.Service/Delegates/Normalizers/AddUserToGroupNormalizer.cs
@@ -1,15 +1,31 @@
-﻿using ACS.Service.Data.Models;
+using System;
+using System.Linq;
+using ACS.Service.Data.Models;
 
 namespace ACS.Service.Delegates.Normalizers
 {
     internal static class AddUserToGroupNormalizer
     {
-        public static List<Group> Groups { get; set; }
-        public static List<User> Users { get; set; }
+        public static List<Group> Groups { get; set; } = null!;
+        public static List<User> Users { get; set; } = null!;
         public static void Execute(int userId, int groupId)
         {
-            var user = Users.Single(x => x.Id == userId);
-            var group = Groups.Single(x => x.Id == groupId);
+            if (Groups is null)
+            {
+                throw new InvalidOperationException("Groups collection has not been initialized.");
+            }
+
+            if (Users is null)
+            {
+                throw new InvalidOperationException("Users collection has not been initialized.");
+            }
+
+            var user = Users.SingleOrDefault(x => x.Id == userId)
+                ?? throw new InvalidOperationException($"User {userId} not found.");
+
+            var group = Groups.SingleOrDefault(x => x.Id == groupId)
+                ?? throw new InvalidOperationException($"Group {groupId} not found.");
+
             group.Users.Add(user);
             user.Group = group;
             user.GroupId = group.Id;

--- a/ACS.Service/Delegates/Normalizers/RemoveGroupFromGroupNormalizer.cs
+++ b/ACS.Service/Delegates/Normalizers/RemoveGroupFromGroupNormalizer.cs
@@ -1,20 +1,33 @@
+using System;
+using System.Linq;
 using ACS.Service.Data.Models;
 
 namespace ACS.Service.Delegates.Normalizers
 {
     internal static class RemoveGroupFromGroupNormalizer
     {
-        public static List<Group> Groups { get; set; }
+        public static List<Group> Groups { get; set; } = null!;
         public static void Execute(int childGroupId, int parentGroupId)
         {
-            var parent = Groups.Single(x => x.Id == parentGroupId);
-            var child = Groups.Single(x => x.Id == childGroupId);
-            if (parent.ChildGroups.Contains(child))
+            if (Groups is null)
             {
-                parent.ChildGroups.Remove(child);
-                child.ParentGroup = null;
-                child.ParentGroupId = 0;
+                throw new InvalidOperationException("Groups collection has not been initialized.");
             }
+
+            var parent = Groups.SingleOrDefault(x => x.Id == parentGroupId)
+                ?? throw new InvalidOperationException($"Parent group {parentGroupId} not found.");
+
+            var child = Groups.SingleOrDefault(x => x.Id == childGroupId)
+                ?? throw new InvalidOperationException($"Child group {childGroupId} not found.");
+
+            if (!parent.ChildGroups.Contains(child))
+            {
+                throw new InvalidOperationException($"Child group {childGroupId} is not a member of parent group {parentGroupId}.");
+            }
+
+            parent.ChildGroups.Remove(child);
+            child.ParentGroup = null;
+            child.ParentGroupId = 0;
         }
     }
 }

--- a/ACS.Service/Delegates/Normalizers/RemoveRoleFromGroupNormalizer.cs
+++ b/ACS.Service/Delegates/Normalizers/RemoveRoleFromGroupNormalizer.cs
@@ -1,21 +1,39 @@
-﻿using ACS.Service.Data.Models;
+using System;
+using System.Linq;
+using ACS.Service.Data.Models;
 
 namespace ACS.Service.Delegates.Normalizers
 {
     internal class RemoveRoleFromGroupNormalizer
     {
-        public static List<Group> Groups { get; set; }
-        public static List<Role> Roles { get; set; }
+        public static List<Group> Groups { get; set; } = null!;
+        public static List<Role> Roles { get; set; } = null!;
         public static void Execute(int roleId, int groupId)
         {
-            var role = Roles.Single(x => x.Id == roleId);
-            var group = Groups.Single(x => x.Id == groupId);
-            if (group.Roles.Contains(role))
+            if (Groups is null)
             {
-                group.Roles.Remove(role);
-                role.Group = null;
-                role.GroupId = 0;
+                throw new InvalidOperationException("Groups collection has not been initialized.");
             }
+
+            if (Roles is null)
+            {
+                throw new InvalidOperationException("Roles collection has not been initialized.");
+            }
+
+            var role = Roles.SingleOrDefault(x => x.Id == roleId)
+                ?? throw new InvalidOperationException($"Role {roleId} not found.");
+
+            var group = Groups.SingleOrDefault(x => x.Id == groupId)
+                ?? throw new InvalidOperationException($"Group {groupId} not found.");
+
+            if (!group.Roles.Contains(role))
+            {
+                throw new InvalidOperationException($"Role {roleId} is not a member of group {groupId}.");
+            }
+
+            group.Roles.Remove(role);
+            role.Group = null;
+            role.GroupId = 0;
         }
     }
 }

--- a/ACS.Service/Delegates/Normalizers/RemoveUserFromGroupNormalizer.cs
+++ b/ACS.Service/Delegates/Normalizers/RemoveUserFromGroupNormalizer.cs
@@ -1,21 +1,39 @@
-﻿using ACS.Service.Data.Models;
+using System;
+using System.Linq;
+using ACS.Service.Data.Models;
 
 namespace ACS.Service.Delegates.Normalizers
 {
     internal static class RemoveUserFromGroupNormalizer
     {
-        public static List<Group> Groups { get; set; }
-        public static List<User> Users { get; set; }
+        public static List<Group> Groups { get; set; } = null!;
+        public static List<User> Users { get; set; } = null!;
         public static void Execute(int userId, int groupId)
         {
-            var user = Users.Single(x => x.Id == userId);
-            var group = Groups.Single(x => x.Id == groupId);
-            if (group.Users.Contains(user))
+            if (Groups is null)
             {
-                group.Users.Remove(user);
-                user.Group = null;
-                user.GroupId = 0;
+                throw new InvalidOperationException("Groups collection has not been initialized.");
             }
+
+            if (Users is null)
+            {
+                throw new InvalidOperationException("Users collection has not been initialized.");
+            }
+
+            var user = Users.SingleOrDefault(x => x.Id == userId)
+                ?? throw new InvalidOperationException($"User {userId} not found.");
+
+            var group = Groups.SingleOrDefault(x => x.Id == groupId)
+                ?? throw new InvalidOperationException($"Group {groupId} not found.");
+
+            if (!group.Users.Contains(user))
+            {
+                throw new InvalidOperationException($"User {userId} is not a member of group {groupId}.");
+            }
+
+            group.Users.Remove(user);
+            user.Group = null;
+            user.GroupId = 0;
         }
     }
 }

--- a/ACS.Service/Properties/AssemblyInfo.cs
+++ b/ACS.Service/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ACS.Service.Tests.Unit")]
+[assembly: InternalsVisibleTo("ACS.Service.Tests")]

--- a/DEVELOPER_JOURNAL.md
+++ b/DEVELOPER_JOURNAL.md
@@ -80,3 +80,17 @@ Implemented normalizers for managing group hierarchies and wired them into the d
 **Persona:** Lead Developer
 
 Implemented child-side group operations and cycle prevention in the domain. Added mapping logic for HTTP verbs in `CreateUriAccessNormalizer`, expanded domain integration tests for the new methods, and documented the updates in project files and service overview.
+### 2025-08-03
+**Persona:** QA Engineer
+
+Exercised the full test suite, fixed null reference issues in group and membership normalizers, and documented the progress in the test improvement project file.
+
+### 2025-08-03
+**Persona:** Lead Developer
+
+Reworked group and membership normalizers to throw exceptions on missing collections or associations, expanded unit tests to cover the new behavior, and updated project documentation.
+
+### 2025-08-03
+**Persona:** Lead Developer
+
+Addressed review feedback by making normalizers fail when backing collections are unset and extending unit tests to cover null collection scenarios. Updated project docs and verified tests.

--- a/DEVELOPER_JOURNAL.md
+++ b/DEVELOPER_JOURNAL.md
@@ -94,3 +94,8 @@ Reworked group and membership normalizers to throw exceptions on missing collect
 **Persona:** Lead Developer
 
 Addressed review feedback by making normalizers fail when backing collections are unset and extending unit tests to cover null collection scenarios. Updated project docs and verified tests.
+
+### 2025-08-06
+**Persona:** Lead Developer
+
+Renamed service test file for clarity, added missing guard tests for normalizers, ran the full test suite, and refreshed project documentation.

--- a/docs/projects/test_improvement.md
+++ b/docs/projects/test_improvement.md
@@ -19,4 +19,7 @@
 - Added tests verifying domain methods trigger normalizers
 - Added normalizer and domain tests for group hierarchy management
 - Added tests for child-side group operations and cycle prevention
+- Fixed null reference errors in group and membership normalizers so service tests run cleanly
+- Converted group and membership normalizers to throw exceptions when collections or targets are missing
+- Added tests ensuring normalizers throw when their backing collections are null
 

--- a/docs/projects/test_improvement.md
+++ b/docs/projects/test_improvement.md
@@ -22,4 +22,5 @@
 - Fixed null reference errors in group and membership normalizers so service tests run cleanly
 - Converted group and membership normalizers to throw exceptions when collections or targets are missing
 - Added tests ensuring normalizers throw when their backing collections are null
+- Added guard tests for missing parents, groups, roles, and users in normalizers
 


### PR DESCRIPTION
## Summary
- default group, user, and role normalizers to null backing collections and throw `InvalidOperationException` when uninitialized
- add unit tests covering null collection scenarios
- document the additional test coverage in the Test Improvement Initiative log

## Testing
- `dotnet test` *(fails: Microsoft.Data.Tools.Schema.SqlTasks.targets missing)*
- `dotnet test ACS.Service.Tests.Unit/ACS.Service.Tests.Unit.csproj`
- `dotnet test ACS.Service.Tests/ACS.Service.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_b_688f2acde29c8329bd1f553e8664d9b2